### PR TITLE
Add search hints functionality, create SearchHint Component

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,12 +3,13 @@ import LinkedInIcon from '@material-ui/icons/LinkedIn';
 import { Search } from '../Search/Search';
 import { Navigation } from '../Navigation/Navigation';
 import './Header.scss';
+import { userHints } from '../../constants/UserHints';
 
 export const Header: React.FC = () => (
   <header className="header">
     <div className="header__search">
       <LinkedInIcon color="primary" className="header__logo" />
-      <Search />
+      <Search hintsFunction={userHints} />
     </div>
     <Navigation />
   </header>

--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -5,6 +5,8 @@
 .search {
   display: flex;
   align-items: center;
+  flex-direction: column;
+
   padding: 10px;
   height: 22px;
   color: $gray;
@@ -15,6 +17,10 @@
     background-color: $lightGray;
   }
 
+  &__container {
+    display: flex;
+  }
+
   &__input {
     display: none;
 
@@ -23,6 +29,18 @@
       outline: none;
       border: none;
       background: none;
+      color: black;
+    }
+  }
+
+  &__hints {
+    display: none;
+
+    @media only screen and (min-width: $medium) {
+      display: block;
+      padding: 0;
+      margin: 3px 0;
+      width: 100%;
     }
   }
 }

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -2,24 +2,21 @@ import React, { useEffect, useState } from 'react';
 import SearchIcon from '@material-ui/icons/Search';
 import PropTypes from 'prop-types';
 import './Search.scss';
-import db from '../../firebase';
 import { SearchHint } from '../SearchHint/SearchHint';
 
-export const Search: React.FC<{ testId?: string }> = ({ testId }) => {
+interface SearchProps {
+  testId?: string;
+  hintsFunction?: (set: React.Dispatch<React.SetStateAction<string[]>>, value: string) => void;
+}
+
+export const Search: React.FC<SearchProps> = ({ testId, hintsFunction }) => {
   const [searchInput, setSearchInput] = useState('');
-  const [searchHints, setSearchHints] = useState<{ id: string; displayName: string }[]>([]);
+  const [searchHints, setSearchHints] = useState<string[]>([]);
 
   useEffect(() => {
-    db.collection('users')
-      .orderBy('displayName', 'asc')
-      .onSnapshot(snapshot => {
-        setSearchHints(
-          snapshot.docs
-            .map(doc => ({ id: doc.id, displayName: doc.data().displayName }))
-            .filter(doc => doc.displayName.startsWith(searchInput) && searchInput)
-            .slice(0, 5)
-        );
-      });
+    if (hintsFunction) {
+      hintsFunction(setSearchHints, searchInput);
+    }
   }, [searchInput]);
 
   return (
@@ -36,8 +33,8 @@ export const Search: React.FC<{ testId?: string }> = ({ testId }) => {
         />
       </div>
       <ul className="search__hints">
-        {searchHints.map(({ id, displayName }) => (
-          <SearchHint key={id} hint={displayName} />
+        {searchHints.map(hint => (
+          <SearchHint hint={hint} />
         ))}
       </ul>
     </div>
@@ -45,5 +42,6 @@ export const Search: React.FC<{ testId?: string }> = ({ testId }) => {
 };
 
 Search.propTypes = {
-  testId: PropTypes.string.isRequired
+  testId: PropTypes.string.isRequired,
+  hintsFunction: PropTypes.func.isRequired
 };

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,10 +1,49 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import SearchIcon from '@material-ui/icons/Search';
+import PropTypes from 'prop-types';
 import './Search.scss';
+import db from '../../firebase';
+import { SearchHint } from '../SearchHint/SearchHint';
 
-export const Search: React.FC = () => (
-  <div className="search">
-    <SearchIcon className="search__icon" />
-    <input placeholder="Search..." className="search__input" type="text" />
-  </div>
-);
+export const Search: React.FC<{ testId?: string }> = ({ testId }) => {
+  const [searchInput, setSearchInput] = useState('');
+  const [searchHints, setSearchHints] = useState<{ id: string; displayName: string }[]>([]);
+
+  useEffect(() => {
+    db.collection('users')
+      .orderBy('displayName', 'asc')
+      .onSnapshot(snapshot => {
+        setSearchHints(
+          snapshot.docs
+            .map(doc => ({ id: doc.id, displayName: doc.data().displayName }))
+            .filter(doc => doc.displayName.startsWith(searchInput) && searchInput)
+            .slice(0, 5)
+        );
+      });
+  }, [searchInput]);
+
+  return (
+    <div className="search">
+      <div className="search__container">
+        <SearchIcon className="search__icon" />
+        <input
+          value={searchInput}
+          onChange={e => setSearchInput(e.target.value)}
+          data-testid={testId}
+          placeholder="Search..."
+          className="search__input"
+          type="text"
+        />
+      </div>
+      <ul className="search__hints">
+        {searchHints.map(({ id, displayName }) => (
+          <SearchHint key={id} hint={displayName} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+Search.propTypes = {
+  testId: PropTypes.string.isRequired
+};

--- a/src/components/SearchHint/SearchHint.scss
+++ b/src/components/SearchHint/SearchHint.scss
@@ -1,0 +1,18 @@
+@import '../../styles/Colors.scss';
+
+.searchHint {
+  list-style-type: none;
+  padding: 10px 5px;
+  background-color: $white;
+  border: 1px solid $lightGray;
+  border-top: none;
+
+  &:hover {
+    color: $linkedinBlue;
+  }
+
+  &__link {
+    text-decoration: none;
+    color: $black;
+  }
+}

--- a/src/components/SearchHint/SearchHint.tsx
+++ b/src/components/SearchHint/SearchHint.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import './SearchHint.scss';
+
+export const SearchHint: React.FC<{ hint: string }> = ({ hint }) => (
+  <Link className="searchHint__link" to={`/profile/${hint}`}>
+    <li className="searchHint">{hint}</li>
+  </Link>
+);
+
+SearchHint.propTypes = {
+  hint: PropTypes.string.isRequired
+};

--- a/src/constants/UserHints.ts
+++ b/src/constants/UserHints.ts
@@ -1,0 +1,14 @@
+import db from '../firebase';
+
+export const userHints: (set: React.Dispatch<React.SetStateAction<string[]>>, value: string) => void = (set, value) => {
+  db.collection('users')
+    .orderBy('displayName', 'asc')
+    .onSnapshot(snapshot => {
+      set(
+        snapshot.docs
+          .map(doc => doc.data().displayName)
+          .filter(doc => doc.startsWith(value) && value)
+          .slice(0, 5)
+      );
+    });
+};

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -4,15 +4,16 @@ import { FormLayout } from '../pages/FormLayout/FormLayout';
 import { Welcome } from '../pages/Welcome/Welcome';
 import { DefaultRoute } from './DefaultRoute';
 import { ProtectedRoute } from './ProtectedRoute';
-import { Logo } from '../shared/components/Logo/Logo';
+
 import { SignupForm } from '../components/SignupForm/SignupForm';
 import { LoginForm } from '../components/LoginForm/LoginForm';
+import { Header } from '../components/Header/Header';
 
 export const Routes = [
   <Route exact path="/" component={Welcome} />,
   <Route exact path="/signUp" render={() => <FormLayout formComponent={<SignupForm />} />} />,
   <Route exact path="/signIn" render={() => <FormLayout formComponent={<LoginForm />} />} />,
-  <ProtectedRoute path="/feed" component={Logo} />,
+  <ProtectedRoute path="/feed" component={Header} />,
   <ProtectedRoute exact path="/network" />,
   <ProtectedRoute exact path="/notification" />,
   <DefaultRoute />

--- a/src/styles/Colors.scss
+++ b/src/styles/Colors.scss
@@ -3,6 +3,8 @@ $lightBlue: #c4cfdb;
 $linkedinBlue: #3f51b5;
 $darkBlue: #0a66c2;
 $gold: #e0b172;
+$white: white;
+$black: black;
 $lightGray: lightgray;
 $gray: gray;
 $mainTheme: linear-gradient(0deg, rgba(40, 103, 178, 0.28895308123249297) 0%, rgba(255, 255, 255, 1) 71%);


### PR DESCRIPTION
# Related issue
- Search

# Changes
- Add search hints functionality, create SearchHint Component, user see suggestions by typed pattern, user can click suggestion and he will be redirected to clicked user profile.

# Additional information
-I failed to make the component expandable. For example, that there would be a possibility of hints from another collection in the database

# Checklist
- [X] Performed self-review
- [ ] Added data-testId for UI elements
- [ ] Tests
- [ ] Storybook / hard to add because it depends on another component

# Screenshots

![image](https://user-images.githubusercontent.com/87152087/127148976-35b4f7fd-f138-441e-805f-cdae74f24a47.png)
![image](https://user-images.githubusercontent.com/87152087/127149033-d9c665a6-383a-4a93-8af2-ff2bc66162a7.png)


