### PR TITLE
Fix UserCard border on mobile, UserCard info now wrap

### DIFF
--- a/src/components/UserCard/UserCard.scss
+++ b/src/components/UserCard/UserCard.scss
@@ -8,6 +8,8 @@
   max-width: 200px;
   margin: 10px;
   box-shadow: none;
+  word-break: break-all;
+  text-align: center;
 
   @media only screen and (min-width: $mobile) {
     width: 200px;

--- a/src/pages/MyNetwork/MyNetwork.scss
+++ b/src/pages/MyNetwork/MyNetwork.scss
@@ -10,7 +10,7 @@
 
   &__container {
     margin: 20px 0;
-    width: 60vw;
+    width: 65vw;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/styles/Mixins.scss
+++ b/src/styles/Mixins.scss
@@ -1,4 +1,4 @@
-@import "./Breakpoints";
+@import './Breakpoints';
 
 @mixin flexCenter {
   display: flex;
@@ -16,14 +16,9 @@
 @mixin cardStyling {
   max-width: 700px;
   width: 100%;
-  border-top: 1px solid $lightGray;
-  border-bottom: 1px solid $lightGray;
+  border: 1px solid $lightGray;
+  border-radius: 15px;
   background: $white;
-  
-  @media only screen and (min-width: $mobile) {
-    border: 1px solid $lightGray;
-    border-radius: 15px;
-  }
 }
 
 @mixin flexWrap {


### PR DESCRIPTION
# Related issue
- UserCards in MyNetwork dont have border on smaller devices,username dont wrap

# Changes
- UserCard now look normal on smaller devices and username wrap and look cool

# Additional information
- There are not any additional information or context

# Checklist
- [x] Performed self-review
- [ ] Added data-testId for UI elements
- [ ] Tests
- [ ] Storybook

# Screenshots

![image](https://user-images.githubusercontent.com/87152087/129727267-d4ed7485-e7e7-4007-9871-26ff45beed4b.png)
